### PR TITLE
Issue when adding the splash view in viewDidLoad

### DIFF
--- a/Classes/CBZSplashView.m
+++ b/Classes/CBZSplashView.m
@@ -41,7 +41,7 @@
     return;
   }
   
-  self.frame = [UIApplication sharedApplication].keyWindow.frame;
+  self.frame = [[UIScreen mainScreen] bounds];
   self.backgroundColor = self.backgroundViewColor;
 
   self.iconImageView = [UIImageView new];


### PR DESCRIPTION
Hi,

Right now, sometimes you can only add the view in `viewDidAppear`. Trying to add it in `viewWillAppear` or `viewDidLoad` would not work, since the the key window is not yet available.

To solve this, I have changed the frame code to `[[UIScreen mainScreen] bounds]`. Now, the splash view can be added at an earlier stage of the app launch without any issues.

Maz
